### PR TITLE
Fix: Use fixed scope

### DIFF
--- a/.github/workflows/exodide.yml
+++ b/.github/workflows/exodide.yml
@@ -13,8 +13,8 @@ jobs:
           context: .
           push: false
           tags: exodide/results:latest
-          cache-to: type=gha,mode=max,scope=${{github.ref_name}}
-          cache-from: type=gha,scope=${{github.ref_name}}
+          cache-to: type=gha,mode=max,scope=exodide
+          cache-from: type=gha,scope=exodide
           load: true
       - run: |
           docker create --name results exodide/results:latest


### PR DESCRIPTION
github.ref_name become
 *  'branch name' for push and
 *  '<pull number>/merger' for PR.

Especially for PR, scope always become unique and no cache is hit.

To maximize cache hit, we use fixed scope.