### PR TITLE
Remove README.md from test dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ RUN git clone --depth 1 https://github.com/emscripten-core/emsdk.git /emsdk && \
     ./emsdk install ${EMSCRIPTEN_VERSION} && \
     ./emsdk activate ${EMSCRIPTEN_VERSION} && \
     rm -rf /emsdk/.git
+SHELL ["/bin/bash", "-c"]
 
 
 FROM base AS build-base
-SHELL ["/bin/bash", "-c"]
 COPY Makefile /exodide/
 COPY exodide  /exodide/exodide/
 COPY numpy    /exodide/numpy/
@@ -19,7 +19,6 @@ COPY script   /exodide/script/
 WORKDIR /exodide
 RUN source /emsdk/emsdk_env.sh && \
     make && rm -rf numpy cpython pyodide script && rm -f Makefile
-SHELL ["/bin/bash", "-c"]
 
 
 FROM build-base AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY script   /exodide/script/
 WORKDIR /exodide
 RUN source /emsdk/emsdk_env.sh && \
     make && rm -rf numpy cpython pyodide script && rm -f Makefile
+SHELL ["/bin/bash", "-c"]
 
 
 FROM build-base AS build
@@ -32,13 +33,11 @@ RUN python3 setup.py bdist_wheel -d /dist && rm -rf /exodide
 
 
 FROM base AS exodide
-SHELL ["/bin/bash", "-c"]
 COPY --from=build /dist /dist/
 RUN pip3 install /dist/* wheel && rm -rf /dist
 
 
 FROM base AS exodide-no-readme
-SHELL ["/bin/bash", "-c"]
 COPY --from=build /dist /dist/
 RUN pip3 install /dist/* wheel && rm -rf /dist
 


### PR DESCRIPTION
To maximize cache hit, we remove README.md from test dependency,
because README.md should not affect test.