### PR TITLE
HotFix: linker args

### DIFF
--- a/exodide/build.py
+++ b/exodide/build.py
@@ -98,7 +98,12 @@ def exodide_unsupported_links() -> List[str]:
     list of str
         Unsupported link arguments for exodide
     """
-    return ["-shared", "-pthread"]
+    return ["-shared", "-pthread",
+            "-Wl,-Bsymbolic-functions",
+            "-Wl,--strip-all",
+            "-Wl,-strip-all",
+            "-Wl,--sort-common",
+            "-Wl,--as-needed"]
 
 
 def exodide_platform_tag() -> str:

--- a/test/test_exodide.py
+++ b/test/test_exodide.py
@@ -37,7 +37,12 @@ class TestBuild(unittest.TestCase):
 
     def test_exodided_unsupported_links(self):
         self.assertEqual(build.exodide_unsupported_links(),
-                         ["-shared", "-pthread"])
+                         ["-shared", "-pthread",
+                          "-Wl,-Bsymbolic-functions",
+                          "-Wl,--strip-all",
+                          "-Wl,-strip-all",
+                          "-Wl,--sort-common",
+                          "-Wl,--as-needed"])
 
     def test_platform_tag(self):
         self.assertEqual(build.exodide_platform_tag(), "emscripten-wasm32")


### PR DESCRIPTION
For #26: At some environment, `setup()` adds more linker options which `wasm-ld` cannot handle.

We try to delete 5 options as Pyodide do;
https://github.com/pyodide/pyodide/blob/7231cab3ffc83f6221fafb7458f9b223d2a7c759/pyodide-build/pyodide_build/pywasmcross.py#L295-L301

Pyodide also delete other prefix options like `--sysroot=` etc,
however, we assume they are not automatically set by `setup()` but manually specified by users.
