### PR TITLE
Update examples with v1.0.4

### DIFF
--- a/example-spaCy/Dockerfile
+++ b/example-spaCy/Dockerfile
@@ -8,7 +8,7 @@ RUN pip download numpy cython \
     -d /deps
 
 
-FROM ghcr.io/ymd-h/exodide:v1.0.2 AS build-base
+FROM ghcr.io/ymd-h/exodide:v1.0.4 AS build-base
 COPY --from=deps /deps /deps/
 RUN pip install /deps/*
 

--- a/example-spaCy/README.md
+++ b/example-spaCy/README.md
@@ -9,7 +9,7 @@ Pyodide. Fortunately, spaCy uses relatively simple build system.
 
 ```shell
 docker build -t example-spacy:latest .
-docker run -p 8000:8000 example-spacy:latest
+docker run -it -p 8000:8000 example-spacy:latest
 ```
 
 then open `localhost:8000/index.html` with your browser.

--- a/example-spaCy/index.html
+++ b/example-spaCy/index.html
@@ -28,22 +28,19 @@
 import micropip
 from pyodide import to_js, http, JsProxy
 
-await micropip.install(["exodide",
-                        "wasabi", "catalogue", "typer", "pathy",
-                        "tqdm", "requests", "jinja2",
-                        "langcodes", "typing_extensions"])
-from exodide.install import fetch_install
-pkg = ["blis-0.7.8",
-       "cymem-2.0.6",
-       "murmurhash-1.0.7",
-       "preshed-3.0.6",
-       "srsly-2.4.3",
-       "thinc-8.1.0",
-       "spacy-3.4.0"]
+pkg = [f"./{p}-cp310-cp310-emscripten_3_1_14_wasm32.whl"
+       for p in ["blis-0.7.8",
+                 "cymem-2.0.6",
+                 "murmurhash-1.0.7",
+                 "preshed-3.0.6",
+                 "srsly-2.4.3",
+                 "thinc-8.1.0",
+                 "spacy-3.4.0"]]
 
-for p in pkg:
-    await fetch_install(f"{p}-cp310-cp310-emscripten_3_1_14_wasm32.whl")
-await fetch_install("en_core_web_sm-3.4.0-py3-none-any.whl")
+await micropip.install(["wasabi", "catalogue<2.1.0", "typer<0.5.0", "pathy",
+                        "tqdm", "requests", "jinja2",
+                        "langcodes", "typing_extensions",
+                        "./en_core_web_sm-3.4.0-py3-none-any.whl"] + pkg)
 
 
 import spacy

--- a/example-spaCy/index.html
+++ b/example-spaCy/index.html
@@ -25,7 +25,6 @@
       const pyodide = await loadPyodide();
       await pyodide.loadPackage(["micropip", "numpy", "pydantic"]);
       const tokenize = await pyodide.runPythonAsync(`
-import importlib
 import micropip
 from pyodide import to_js, http, JsProxy
 

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ymd-h/exodide:v1.0.3 AS build
+FROM ghcr.io/ymd-h/exodide:v1.0.4 AS build
 COPY exodide_example /src/exodide_example/
 COPY pybind11 /src/pybind11/
 COPY setup.py /src/

--- a/example/index_pyscript.html
+++ b/example/index_pyscript.html
@@ -14,7 +14,7 @@
       <div id="fibonacci"></div>
     </div>
     <py-env>
-      - exodide
+      - "./dist/exodide_example-0.0.1-cp310-cp310-emscripten_3_1_14_wasm32.whl"
     </py-env>
     <py-config>
       name: "exodide-pyscript"
@@ -22,9 +22,6 @@
         - src: "https://cdn.jsdelivr.net/pyodide/v0.21.0/full/pyodide.js"
     </py-config>
     <py-script>
-      # asyncio
-      from exodide.install import fetch_install
-      await fetch_install("dist/exodide_example-0.0.1-cp310-cp310-emscripten_3_1_14_wasm32.whl")
       import exodide_example as ee
 
       ee.hello_world()


### PR DESCRIPTION
Related with #32 

* Update example base image to v1.0.4
* Use `micropip` to install custom C/C++ packages
* Fix: Add `-it` option to docker command on `example-spaCy/README.md`